### PR TITLE
Add note about volatile DEFAULT which still causes rewrite table

### DIFF
--- a/rules/adding-field-with-default/message.md
+++ b/rules/adding-field-with-default/message.md
@@ -6,6 +6,8 @@ On Postgres versions less than 11, adding a field with a DEFAULT requires a tabl
 
 An `ACCESS EXCLUSIVE` lock blocks reads/writes while the statement is running.
 
+Postgres version 11 and newer still requires the entire table and its indexes to be rewritten with an ACCESS EXCLUSIVE lock in case of adding a column with a volatile DEFAULT e.g. random(), clock_timestamp().
+
 # Solution
 
 Add the field as nullable, then set a default, backfill, and remove nullabilty.


### PR DESCRIPTION
https://www.postgresql.org/docs/11/sql-altertable.html#SQL-ALTERTABLE-NOTES

>When a column is added with ADD COLUMN and a non-volatile DEFAULT is specified, the default is evaluated at the time of the statement and the result stored in the table's metadata. That value will be used for the column for all existing rows. If no DEFAULT is specified, NULL is used. In neither case is a rewrite of the table required.

>Adding a column with a volatile DEFAULT or changing the type of an existing column will require the entire table and its indexes to be rewritten